### PR TITLE
Allow externally provided weights path and feature dimensions in Ligh…

### DIFF
--- a/RDD/matchers/lightglue.py
+++ b/RDD/matchers/lightglue.py
@@ -385,7 +385,8 @@ class LightGlue(nn.Module):
                     f"{{{','.join(self.features)}}}"
                 )
             for k, v in self.features[features].items():
-                setattr(conf, k, v)
+                if not hasattr(conf, k):
+                    setattr(conf, k, v)
 
         if conf.input_dim != conf.descriptor_dim:
             self.input_proj = nn.Linear(conf.input_dim, conf.descriptor_dim, bias=True)


### PR DESCRIPTION
…tGlue

Current implementation will always modify LightGlue.conf so that the weights path and input_dim come from the hardcoded values in LightGlue.features. This change allows user-provided values to persist, only using the hard-coded values if the user does not provide values.