### PR TITLE
Respect explicit weights for RDD LightGlue

### DIFF
--- a/RDD/matchers/lightglue.py
+++ b/RDD/matchers/lightglue.py
@@ -385,6 +385,12 @@ class LightGlue(nn.Module):
                     f"{{{','.join(self.features)}}}"
                 )
             for k, v in self.features[features].items():
+                if (
+                    features == "rdd"
+                    and k == "weights"
+                    and getattr(conf, "weights", None) is not None
+                ):
+                    continue
                 setattr(conf, k, v)
 
         if conf.input_dim != conf.descriptor_dim:


### PR DESCRIPTION
## Summary
- avoid overwriting an explicitly provided `weights` path when `features="rdd"`
- keeps current behavior for other feature presets

## Repro
```python
from RDD.matchers import LightGlue
LightGlue("rdd", weights="/abs/path/to/rdd_lg_v2.ckpt")
# currently attempts to load ./weights/RDD_lg-v2.pth instead
```

## Fix
When merging feature defaults in `RDD/matchers/lightglue.py`, skip overriding `conf.weights` if it is already provided for `rdd`.

## Context
This shows up in https://github.com/gmberton/image-matching-models/issues/51 where `rdd-lg` passes a custom weight path; the current overwrite produces `FileNotFoundError: ./weights/RDD_lg-v2.pth` unless CWD happens to contain that file.

Fixes #16
